### PR TITLE
Add variable to customize date format on done tasks

### DIFF
--- a/doc/taskpaper.txt
+++ b/doc/taskpaper.txt
@@ -97,6 +97,17 @@ projects.
 To show all projects and tasks use the `\ta` command. This disables folding so
 that the entire file is expanded.
 
+Configuration
+==============
+
+To change the default date format string used when marking a task complete,
+define the `task_paper_date_format` variable. The format matches your system's
+`strftime()` function.
+
+For example, to include the date and time in ISO8601 format:
+
+    let g:task_paper_date_format = "%Y-%m-%dT%H:%M:%S%z"
+
 File-type Detection
 ====================
 

--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -12,7 +12,7 @@ if exists("loaded_task_paper")
 endif
 let loaded_task_paper = 1
 
-# Define a default date format
+" Define a default date format
 if !exists('task_paper_date_format') | let task_paper_date_format = "%Y-%m-%d" | endif
 
 "add '@' to keyword character set so that we can complete contexts as keywords

--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -12,6 +12,9 @@ if exists("loaded_task_paper")
 endif
 let loaded_task_paper = 1
 
+# Define a default date format
+if !exists('task_paper_date_format') | let task_paper_date_format = "%Y-%m-%d" | endif
+
 "add '@' to keyword character set so that we can complete contexts as keywords
 setlocal iskeyword+=@-@
 
@@ -56,7 +59,7 @@ function! s:ToggleDone()
             let repl = substitute(line, "@done\(.*\)", "", "g")
             echo "undone!"
         else
-            let today = strftime("%Y-%m-%d", localtime())
+            let today = strftime(g:task_paper_date_format, localtime())
             let done_str = " @done(" . today . ")"
             let repl = substitute(line, "$", done_str, "g")
             echo "done!"


### PR DESCRIPTION
The "task_paper_date_format" variable allows customization of the date in the @done() context.  The default remains year-month-day (%Y-%m-%d).

Documentation includes "Customization" section documenting the new variable and how it is used.
