### PR TITLE
Always use tabs instead of spaces

### DIFF
--- a/ftdetect/taskpaper.vim
+++ b/ftdetect/taskpaper.vim
@@ -6,5 +6,6 @@
 " Last Change:  2007 Sep 25
 "
 augroup taskpaper
-     au! BufRead,BufNewFile *.taskpaper   setfiletype taskpaper
+     au! BufRead,BufNewFile *.taskpaper,*.todo   setfiletype taskpaper
+     autocmd FileType taskpaper setlocal noexpandtab
 augroup END


### PR DESCRIPTION
Taskpaper uses tabs instead of spaces for nesting. I've added a line to ftdetect/taskpaper.vim so it sets noexpandtab for taskpaper files. I've also added taskpaper detection for *.todo files.
