### PR TITLE
Disabled autoindent

### DIFF
--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -20,6 +20,9 @@ setlocal foldmethod=syntax
 setlocal foldlevel=99
 setlocal nofoldenable
 
+" Disable autoindent to prevent the <cr> mappings from adding sub-tasks
+setlocal noautoindent
+
 "show tasks from context under the cursor
 function! s:ShowContext()
     let s:wordUnderCursor = expand("<cword>")


### PR DESCRIPTION
When autoindent is enabled adding a new task with <cr> would always add
sub-tasks making it very hard to add several tasks in a row.

Maybe such a small change would be better of left as an issue discussion but I made a pull request anyway. Your are welcome to close it.
