### PR TITLE
Pull Request: @active tag

### DIFF
--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -2,12 +2,44 @@
 " Language:	Taskpaper (http://hogbaysoftware.com/projects/taskpaper)
 " Maintainer:	David O'Callaghan <david.ocallaghan@cs.tcd.ie>
 " URL:		https://github.com/davidoc/taskpaper.vim
-" Last Change:  2011-02-15
+" Last Change:  2011-10-21
+" Changes By: Filipe Silva <d4rchangel@gmail.com>
 
 if exists("loaded_task_paper")
-    finish
+	finish
 endif
 let loaded_task_paper = 1
+
+"Altered by Filipe Silva @ 21/10/2011
+"Em
+"Variables to control the scope of the @active tag removal 
+"when switching active tasks
+"
+"Possible removal scopes:
+" "FILE": When setting a task as active, remove all other active tags
+"         from the whole file (allows only 1 active tag) 
+"         (This is the default value)
+" "PROJECT": When setting a task as active, remove other active tags
+"            from the current project only (allows 1 active tag per project)
+" "NOTHING": When setting a task as active, do not remove other active tags
+"
+if exists("b:task_paper_active_rag_removal_scope")
+	let s:task_paper_active_rag_removal_scope=b:task_paper_active_rag_removal_scope
+else
+	if exists("t:task_paper_active_rag_removal_scope")
+		let s:task_paper_active_rag_removal_scope=t:task_paper_active_rag_removal_scope
+	else
+		if exists("w:task_paper_active_rag_removal_scope")
+			let s:task_paper_active_rag_removal_scope=w:task_paper_active_rag_removal_scope
+		else
+			if exists("g:task_paper_active_rag_removal_scope")
+				let s:task_paper_active_rag_removal_scope=g:task_paper_active_rag_removal_scope
+			else
+				let s:task_paper_active_rag_removal_scope="FILE"
+			endif
+		endif
+	endif
+endif
 
 " Define a default date format
 if !exists('task_paper_date_format') | let task_paper_date_format = "%Y-%m-%d" | endif
@@ -22,71 +54,117 @@ setlocal nofoldenable
 
 "show tasks from context under the cursor
 function! s:ShowContext()
-    let s:wordUnderCursor = expand("<cword>")
-    if(s:wordUnderCursor =~ "@\k*")
-        let @/ = "\\<".s:wordUnderCursor."\\>"
-        "adapted from http://vim.sourceforge.net/tips/tip.php?tip_id=282
-        setlocal foldexpr=(getline(v:lnum)=~@/)?0:1
-        setlocal foldmethod=expr foldlevel=0 foldcolumn=1 foldminlines=0
-        setlocal foldenable
-    else
-        echo "'" s:wordUnderCursor "' is not a context."    
-    endif
+	let s:wordUnderCursor = expand("<cword>")
+	if(s:wordUnderCursor =~ "@\k*")
+		let @/ = "\\<".s:wordUnderCursor."\\>"
+		"adapted from http://vim.sourceforge.net/tips/tip.php?tip_id=282
+		setlocal foldexpr=(getline(v:lnum)=~@/)?0:1
+		setlocal foldmethod=expr foldlevel=0 foldcolumn=1 foldminlines=0
+		setlocal foldenable
+	else
+		echo "'" s:wordUnderCursor "' is not a context."    
+	endif
 endfunction
 
 function! s:ShowAll()
-    setlocal foldmethod=syntax
-    %foldopen!
-    setlocal nofoldenable
+	setlocal foldmethod=syntax
+	%foldopen!
+	setlocal nofoldenable
 endfunction  
 
 function! s:FoldAllProjects()
-    setlocal foldmethod=syntax
-    setlocal foldenable
-    %foldclose! 
+	setlocal foldmethod=syntax
+	setlocal foldenable
+	%foldclose! 
 endfunction
 
 " toggle @done context tag on a task
 function! s:ToggleDone()
 
-    let line = getline(".")
-    if (line =~ '^\s*- ')
-        let repl = line
-        if (line =~ '@done')
-            let repl = substitute(line, "@done\(.*\)", "", "g")
-            echo "undone!"
-        else
-            let today = strftime(g:task_paper_date_format, localtime())
-            let done_str = " @done(" . today . ")"
-            let repl = substitute(line, "$", done_str, "g")
-            echo "done!"
-        endif
-        call setline(".", repl)
-    else 
-        echo "not a task."
-    endif
+	let line = getline(".")
+	if (line =~ '^\s*- ')
+		let repl = line
+		if (line =~ '@done')
+			let repl = substitute(line, "@done\(.*\)", "", "g")
+			echo "undone!"
+		else
+			let today = strftime(g:task_paper_date_format, localtime())
+			let done_str = " @done(" . today . ")"
+			let repl = substitute(line, "$", done_str, "g")
+			echo "done!"
+		endif
+		call setline(".", repl)
+	else 
+		echo "not a task."
+	endif
 
 endfunction
 
 " toggle @cancelled context tag on a task
 function! s:ToggleCancelled()
 
-    let line = getline(".")
-    if (line =~ '^\s*- ')
-        let repl = line
-        if (line =~ '@cancelled')
-            let repl = substitute(line, "@cancelled\(.*\)", "", "g")
-            echo "uncancelled!"
-        else
-            let today = strftime(g:task_paper_date_format, localtime())
-            let cancelled_str = " @cancelled(" . today . ")"
-            let repl = substitute(line, "$", cancelled_str, "g")
-            echo "cancelled!"
-        endif
-        call setline(".", repl)
-    else 
-        echo "not a task."
-    endif
+	let line = getline(".")
+	if (line =~ '^\s*- ')
+		let repl = line
+		if (line =~ '@cancelled')
+			let repl = substitute(line, "@cancelled\(.*\)", "", "g")
+			echo "uncancelled!"
+		else
+			let today = strftime(g:task_paper_date_format, localtime())
+			let cancelled_str = " @cancelled(" . today . ")"
+			let repl = substitute(line, "$", cancelled_str, "g")
+			echo "cancelled!"
+		endif
+		call setline(".", repl)
+	else 
+		echo "not a task."
+	endif
+
+endfunction
+
+"Altered by Filipe Silva <d4rchangel@gmail.com>
+"Toggle @active context in a task
+"Ensures there is only one active task at any given time
+
+function! s:ToggleActive()
+
+	"TODO: Function to get the boundaries of a project (if not already existing)
+	"TODO: Limit the tag deletion to the scope of a project
+	let line = getline(".")
+	if (line =~ '^\s*- ')
+		let repl = line
+		let this_line = getpos(".")[1]
+		let this_column = getpos(".")[2]
+		if (line =~ '@active')
+			let repl = substitute(repl, "@active\(.*\)", "", "g")
+			let repl = substitute(repl, "@active", "", "g")
+			echo "Not active!"
+		else
+			"Delete all @active tags in the current scope
+			if s:task_paper_active_rag_removal_scope != "NOTHING"
+				"if s:task_paper_active_rag_removal_scope == "PROJECT"
+
+				let active_pos = search("^\\s*-\\s.*\@[Aa]ctive.*$")
+				while active_pos != 0
+					let active_line = getline(active_pos)
+					"Replace regardless of the tag having a parameter or not
+					let active_line = substitute(active_line, "@active\(.*\)", "", "g")
+					let active_line = substitute(active_line, "@active", "", "g")
+					call setline(active_pos, active_line)
+					let active_pos = search("^\\s*-\\s.*\@[Aa]ctive.*$")
+				endwhile
+			endif
+
+			"return to the line where we were
+			let active_str = " @active"
+			let repl = substitute(line, "$", active_str, "g")
+			call cursor(this_line, this_column)
+			echo "Active!"
+		endif
+		call setline(this_line, repl)
+	else 
+		echo "Not a task."
+	endif
 
 endfunction
 
@@ -96,6 +174,9 @@ noremap <unique> <script> <Plug>ToggleCancelled   :call <SID>ToggleCancelled()<C
 noremap <unique> <script> <Plug>ShowContext      :call <SID>ShowContext()<CR>
 noremap <unique> <script> <Plug>ShowAll          :call <SID>ShowAll()<CR>
 noremap <unique> <script> <Plug>FoldAllProjects  :call <SID>FoldAllProjects()<CR>
+"Altered by Filipe Silva <d4rchangel@gmail.com>
+noremap <unique> <script> <Plug>ToggleActive       :call <SID>ToggleActive()<CR>
+map <buffer> <silent> <Leader>tq <Plug>ToggleActive
 
 map <buffer> <silent> <Leader>td <Plug>ToggleDone
 map <buffer> <silent> <Leader>tx <Plug>ToggleCancelled

--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -167,8 +167,8 @@ function! s:ToggleActive()
 		let this_line = getpos(".")[1]
 		let this_column = getpos(".")[2]
 		if (line =~ '@active')
-			let repl = substitute(repl, "\s*@active\(.*\)", "", "g")
-			let repl = substitute(repl, "\s*@active", "", "g")
+			let repl = substitute(repl, "\\s*@active\(.*\)", "", "g")
+			let repl = substitute(repl, "\\s*@active", "", "g")
 			echo "Not active!"
 		else
 			"Delete all @active tags in the current scope
@@ -190,16 +190,20 @@ function! s:ToggleActive()
 				while active_pos != 0
 					let active_line = getline(active_pos)
 					"Replace regardless of the tag having a parameter or not
-					let active_line = substitute(active_line, "\s*@active\(.*\)", "", "g")
-					let active_line = substitute(active_line, "\s*@active", "", "g")
+					let active_line = substitute(active_line, "\\s*@active\(.*\)", "", "g")
+					let active_line = substitute(active_line, "\\s*@active", "", "g")
 					call setline(active_pos, active_line)
 					let active_pos = search("^\\s*-\\s.*\@[Aa]ctive.*$", flags, searchEnd)
 				endwhile
 			endif
 
 			"return to the line where we were
-			let active_str = " @active"
-			let repl = substitute(line, "\s*$", active_str, "g")
+			let active_str = "@active"
+			if !(line =~ "\s$")
+				let active_str = ' ' . active_str "add a space if there is none at the end of the line
+			endif
+
+			let repl = substitute(line, "\\s*$", active_str, "g")
 			call cursor(this_line, this_column)
 			echo "Active!"
 		endif

--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -51,7 +51,7 @@ endfunction
 function! s:ToggleDone()
 
 	let line = getline(".")
-	if (line =~ '^\s*- ')
+	if (line =~ '^\s*-\s')
 		let repl = line
 		if (line =~ '@done')
 			let repl = substitute(line, "@done\(.*\)", "", "g")
@@ -73,7 +73,7 @@ endfunction
 function! s:ToggleCancelled()
 
 	let line = getline(".")
-	if (line =~ '^\s*- ')
+	if (line =~ '^\s*-\s')
 		let repl = line
 		if (line =~ '@cancelled')
 			let repl = substitute(line, "@cancelled\(.*\)", "", "g")
@@ -103,7 +103,7 @@ function! s:GetTaskpaperProjectBoundaries()
 	let projregex = '^.\+:\s*$'
 
 	let projstart = search(projregex, 'bWc') "Gets the line with the beginning of the current project (possibly the current line)
-	while projstart != 0 && (getline(projstart) =~ '^\s*- ') "Ensure the match is not of a task ending in ':'
+	while projstart != 0 && (getline(projstart) =~ '^\s*-\s') "Ensure the match is not of a task ending in ':'
 		let projstart = search(projregex, 'bWc')
 	endwhile
 
@@ -114,7 +114,7 @@ function! s:GetTaskpaperProjectBoundaries()
 
 	let projend = search(projregex, 'W') "Gets the line with the beginning of the next project 
 
-	while projend != 0 && (getline(projend) =~ '^\s*- ') "Ensure the match is not of a task ending in ':'
+	while projend != 0 && (getline(projend) =~ '^\s*-\s') "Ensure the match is not of a task ending in ':'
 		let projend = search(projregex, 'W')
 	endwhile
 
@@ -143,55 +143,55 @@ function! s:ToggleActive()
 	"            from the current project only (allows 1 active tag per project)
 	" "NOTHING": When setting a task as active, do not remove other active tags
 	"
-	if exists("b:task_paper_active_rag_removal_scope")
-		let s:task_paper_active_rag_removal_scope=b:task_paper_active_rag_removal_scope
+	if exists("b:task_paper_active_tag_removal_scope")
+		let s:task_paper_active_tag_removal_scope=b:task_paper_active_tag_removal_scope
 	else
-		if exists("t:task_paper_active_rag_removal_scope")
-			let s:task_paper_active_rag_removal_scope=t:task_paper_active_rag_removal_scope
+		if exists("t:task_paper_active_tag_removal_scope")
+			let s:task_paper_active_tag_removal_scope=t:task_paper_active_tag_removal_scope
 		else
-			if exists("w:task_paper_active_rag_removal_scope")
-				let s:task_paper_active_rag_removal_scope=w:task_paper_active_rag_removal_scope
+			if exists("w:task_paper_active_tag_removal_scope")
+				let s:task_paper_active_tag_removal_scope=w:task_paper_active_tag_removal_scope
 			else
-				if exists("g:task_paper_active_rag_removal_scope")
-					let s:task_paper_active_rag_removal_scope=g:task_paper_active_rag_removal_scope
+				if exists("g:task_paper_active_tag_removal_scope")
+					let s:task_paper_active_tag_removal_scope=g:task_paper_active_tag_removal_scope
 				else
-					let s:task_paper_active_rag_removal_scope="FILE"
+					let s:task_paper_active_tag_removal_scope="FILE"
 				endif
 			endif
 		endif
 	endif
 
 	let line = getline(".")
-	if (line =~ '^\s*- ')
+	if (line =~ '^\s*-\s')
 		let repl = line
 		let this_line = getpos(".")[1]
 		let this_column = getpos(".")[2]
 		if (line =~ '@active')
-			let repl = substitute(repl, "@active\(.*\)", "", "g")
-			let repl = substitute(repl, "@active", "", "g")
+			let repl = substitute(repl, "\s*@active\(.*\)", "", "g")
+			let repl = substitute(repl, "\s*@active", "", "g")
 			echo "Not active!"
 		else
 			"Delete all @active tags in the current scope
-			if s:task_paper_active_rag_removal_scope != "NOTHING"
-				let searchBegin = line('^') "start at the first line
+			if s:task_paper_active_tag_removal_scope != "NOTHING"
+				let searchBegin = 1 "start at the first line
 				let searchEnd = line('$')   "finish at the last line
 
-				if s:task_paper_active_rag_removal_scope == "PROJECT"
+				if s:task_paper_active_tag_removal_scope == "PROJECT"
 					let projBounds = s:GetTaskpaperProjectBoundaries()
 					let searchBegin = projBounds[0]
 					let searchEnd = projBounds[1]
 				endif
 
 				"Set beginning of the search
-				call cursor(searchBegin, 0)
+				call cursor(searchBegin, 1)
 				let flags = 'c'
 
 				let active_pos = search("^\\s*-\\s.*\@[Aa]ctive.*$", flags, searchEnd)
 				while active_pos != 0
 					let active_line = getline(active_pos)
 					"Replace regardless of the tag having a parameter or not
-					let active_line = substitute(active_line, "@active\(.*\)", "", "g")
-					let active_line = substitute(active_line, "@active", "", "g")
+					let active_line = substitute(active_line, "\s*@active\(.*\)", "", "g")
+					let active_line = substitute(active_line, "\s*@active", "", "g")
 					call setline(active_pos, active_line)
 					let active_pos = search("^\\s*-\\s.*\@[Aa]ctive.*$", flags, searchEnd)
 				endwhile
@@ -199,7 +199,7 @@ function! s:ToggleActive()
 
 			"return to the line where we were
 			let active_str = " @active"
-			let repl = substitute(line, "$", active_str, "g")
+			let repl = substitute(line, "\s*$", active_str, "g")
 			call cursor(this_line, this_column)
 			echo "Active!"
 		endif

--- a/syntax/taskpaper.vim
+++ b/syntax/taskpaper.vim
@@ -25,6 +25,9 @@ syn match  taskpaperListItem  "^\s*[-+]\s\+"
 syn match  taskpaperContext  "@[A-Za-z0-9_]\+"
 syn match  taskpaperDone "^\s*[-+]\s\+.*@[Dd]one.*$"
 syn match  taskpaperCancelled "^\s*[-+]\s\+.*@[Cc]ancelled.*$"
+"Altered by Filipe Silva <d4rchangel@gmail.com>
+"Syntax for an active tag, marking the currently active task
+syn match  taskpaperActive "^\s*[-+]\s\+.*@[Aa]ctive.*$"
 
 syn region taskpaperProjectFold start=/^.\+:\s*$/ end=/^\s*$/ transparent fold
 
@@ -37,6 +40,7 @@ HiLink taskpaperProject       Title
 HiLink taskpaperDone          NonText
 HiLink taskpaperCancelled     NonText
 HiLink taskpaperComment       Comment
+HiLink taskpaperActive				Todo
 
 let b:current_syntax = "taskpaper"
 


### PR DESCRIPTION
Hi!

I'm a fan of the taskpaper format and vim, so naturally I use your plugin very much.

I've recently felt the need to mark a tag as the active one, and felt that is a little more important than just another tag. So I've forked your repository and added syntax and hotkey support for that tag. Now, any task marked with @active is highlighted in the "TODO" color (pink-ish in my color scheme). I've also added a hotkey, <leader>tq, to toggle the current @active tag (I'll explain more below).

As I think more people might appreciate this functionality, I'm making this pull request so that, if you agree, this code can be made available to everyone.

I've changed the syntax file to add highlight support and the ftplugin file for the hotkey function.
I haven't touched the doc files because I don't know very well how the vim doc syntax works yet, and also because I didn't want to mess up anything.

Anyway, the documentation for this function is the following:

***********************************\*    DOCUMENTATION   ***************************************
- Any task (only tasks, not projects) can be marked as @active
- The hotkey <leader>tq will toggle the current @active task in different ways, depending on a variable's value
    (note: <leader>ta was already taken, so I used tq)
  - That variable is task_paper_active_tag_removal_scope, and can be set in the b:, t:, w: or g: scopes (the innermost scopes will override the outermost)
  
  -The variable can have 3 values:
  - "FILE": This means that there can only be one task marked @active in each file. When a task is marked @active (with the hotkey) all other tasks marked @active will have that tag removed (even if they were marked @active by hand). This is the default value (used if the variable is not defined)
  - "PROJECT": This means that there can be one active task per project. If a task is marked @active, all other tags in the same project will have the @active tag removed. Tasks in other projects are left untouched.
  - "NOTHING": This removes any restriction whatsoever on the @active tags. With this setting, any number of tasks in a file can have the @active tag.
    ***********************************\*    END DOCUMENTATION   ***************************************

I hope you agree with me that this can be a useful feature. Anything you need to ask me, feel free to do it.
If you want me to write the documentation for this code, I can do it. Just tell me where to put it (in which section, before/after what text, what links I should include) and I'll do it.

Thank you very much for the plugin. It's very helpful!

Filipe Silva
