### PR TITLE
Fix for Issue 6

### DIFF
--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -53,7 +53,7 @@ function! s:ToggleDone()
     if (line =~ '^\s*- ')
         let repl = line
         if (line =~ '@done')
-            let repl = substitute(line, "@done\(.*\)", "", "g")
+            let repl = substitute(line, " *@done\([^)]*\)", "", "g")
             echo "undone!"
         else
             let today = strftime(g:task_paper_date_format, localtime())
@@ -75,7 +75,7 @@ function! s:ToggleCancelled()
     if (line =~ '^\s*- ')
         let repl = line
         if (line =~ '@cancelled')
-            let repl = substitute(line, "@cancelled\(.*\)", "", "g")
+            let repl = substitute(line, " *@cancelled\([^)]*\)", "", "g")
             echo "uncancelled!"
         else
             let today = strftime(g:task_paper_date_format, localtime())


### PR DESCRIPTION
Previous pattern would erase any tags that occurred after @done, e.g.
@done(2012-02-01) @priority(1). Granted it is not likely you would
have @done before tags it is probably still better to only match non-
right-parens. Simlarly for @cancelled.
