### PR TITLE
Fix for Newline/Leader insertion

### DIFF
--- a/autoload/taskpaper.vim
+++ b/autoload/taskpaper.vim
@@ -461,14 +461,16 @@ function! taskpaper#newline()
     let lnum = line('.')
     let line = getline('.')
 
-    if lnum == 1 || line !~ '^\s*$' ||
-    \  synIDattr(synID(lnum - 1, 1, 1), "name") != 'taskpaperProject'
+    if lnum == 1 || line !~ '^\s*$'
         return ''
     endif
 
     let pline = getline(lnum - 1)
     let depth = len(matchstr(pline, '^\t*'))
-    call setline(lnum, repeat("\t", depth + 1) . '- ')
+    if pline !~ '\s\+-.*'
+        let depth = depth + 1
+    endif
+    call setline(lnum, repeat("\t", depth) . '- ')
 
     return "\<End>"
 endfunction

--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -91,7 +91,7 @@ if !exists("no_plugin_maps") && !exists("no_taskpaper_maps")
     if mapcheck("o", "n") == ''
         nmap <buffer> o <Plug>TaskPaperNewline
     endif
-    if mapcheck("\<CR>", "i") == ''
+    if mapcheck('\<CR>', "i") == ''
         imap <buffer> <CR> <Plug>TaskPaperNewline
     endif
 endif


### PR DESCRIPTION
Should use single quotes instead of double when checking for <CR>. Newline / dash insertion works when creating new item.
