### PR TITLE
don't show invisible characters

### DIFF
--- a/ftplugin/taskpaper.vim
+++ b/ftplugin/taskpaper.vim
@@ -39,6 +39,9 @@ setlocal iskeyword+=@-@
 " Tab character has special meaning on TaskPaper
 setlocal noexpandtab
 
+" don't show invisible characters when working on a taskpaper file
+setlocal nolist
+
 " Change 'comments' and 'formatoptions' to continue to write a task item
 setlocal comments=b:-
 setlocal fo-=c fo+=rol


### PR DESCRIPTION
When the user has `set list`, this should be disabled in .taskpaper files.
